### PR TITLE
bar now extends across mobile page instead of using max width

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uktrade/great-design-system",
   "author": "Matt Simon",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "",
   "engines": {
     "node": "^20.9.0",

--- a/src/components/pagination/_pagination.scss
+++ b/src/components/pagination/_pagination.scss
@@ -1,7 +1,6 @@
 .great-ds-pagination--numbered {
     @include govuk-media-query($until: tablet) {
         align-items: flex-start;
-        max-width: 360px;
 
         .great-ds-pagination__page-summary-container--numbered, 
         .govuk-pagination__prev,


### PR DESCRIPTION
small pagination change to allow grey bar above mobile pagination to cover whole page following design change